### PR TITLE
feat: provide api to move tile in single steps horizontally

### DIFF
--- a/src/gameplay/game.rs
+++ b/src/gameplay/game.rs
@@ -91,6 +91,20 @@ impl Observer for NoopObserver {
     fn signal_board_changed(&self, _: Grid, _: Grid) {}
 }
 
+enum Direction {
+    Left,
+    Right,
+}
+
+impl From<Direction> for i8 {
+    fn from(value: Direction) -> Self {
+        match value {
+            Direction::Left => -1,
+            Direction::Right => 1,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum GameError {
     ObserverFull,
@@ -250,6 +264,27 @@ where
                 self.observer,
             ))
         }
+    }
+
+    fn move_tile_horizontally(&mut self, dir: Direction) -> Result<(), GameError> {
+        let dir: i8 = dir.into();
+        let candidate = self.s.tile.clone().displace_by(dir.into(), 0);
+
+        if self.s.board.is_position_valid(&candidate) {
+            self.s.tile = candidate;
+            self.signal_board_changed();
+            Ok(())
+        } else {
+            Err(GameError::InvalidMove)
+        }
+    }
+
+    pub fn move_tile_right(&mut self) -> Result<(), GameError> {
+        self.move_tile_horizontally(Direction::Right)
+    }
+
+    pub fn move_tile_left(&mut self) -> Result<(), GameError> {
+        self.move_tile_horizontally(Direction::Left)
     }
 
     /// Tries to move the tile horizontally to `column`.

--- a/src/gameplay/game.rs
+++ b/src/gameplay/game.rs
@@ -294,34 +294,6 @@ where
         self.move_tile_horizontally(Direction::Left)
     }
 
-    /// Tries to move the tile horizontally to `column`.
-    ///
-    /// If moving the tile to `column` is not valid, the tile is moved as far as possible.
-    ///
-    /// **Caution:** the column is counted 1-indexed here!
-    ///
-    /// # Panics
-    ///
-    /// If specified column cannot be converted to an `i32`, i.e. if
-    /// `let _ : i32 = column.try_into().unwrap()` panics.
-    pub fn move_tile_up_to(&mut self, column: u32) {
-        let column: i32 = column.try_into().unwrap();
-        let mut direction = (column - self.s.tile.displ_x()).signum();
-        let mut candidate = self.s.tile.clone().displace_by(direction, 0);
-        let mut changed = false;
-
-        while direction != 0 && self.s.board.is_position_valid(&candidate) {
-            self.s.tile = candidate;
-            changed = true;
-
-            direction = (column - self.s.tile.displ_x()).signum();
-            candidate = self.s.tile.clone().displace_by(direction, 0);
-        }
-        if changed {
-            self.signal_board_changed();
-        }
-    }
-
     pub fn rotate_tile(&mut self) -> Result<(), GameError> {
         let candidate = self.s.tile.clone().rotate_ccw();
 


### PR DESCRIPTION
Summary of changes implemented in this PR:

- add functions `move_tile_left` and `move_tile_right` to `Game<TileFloating, O>`
  to move tile in single steps horizontally
- drop function `move_tile_up_to`

Closes #27 