### PR TITLE
refactoring: speed up processing of populated rows

### DIFF
--- a/src/gameplay/board.rs
+++ b/src/gameplay/board.rs
@@ -131,6 +131,12 @@ impl Board<ProcessesRows> {
     /// the transitions between rows to check (as opposed to the rows themselves).
     #[must_use]
     pub fn process_row(self) -> Either<Board<ProcessesRows>, Board<TakesTile>> {
+        // Note that by design, the bottom row cannot be empty when entering
+        // this function (we've just dropped a tile).
+        // Consequently, when entering this function we may always first check
+        // the current row for being fully populated (as opposed to checking it
+        // for being empty).
+
         // Check current row for being fully populated
         let fully_populated = self
             .grid

--- a/src/gameplay/board.rs
+++ b/src/gameplay/board.rs
@@ -246,9 +246,10 @@ mod tests {
             grid: initial_grid.into(),
         };
 
-        // Two rows are fully populated, hence we have to call `process_row` BOARD_ROWS + 2 - 1 times.
+        // Four rows are non-empty of which two rows are fully populated, hence we have to call
+        // `process_row` 4 times.
         // The last call to `process_row` will produce an Either::right value
-        for iter in 1..(BOARD_ROWS + 2) {
+        for iter in 1..4 {
             board = match board.process_row() {
                 Either::Left(board) => board,
                 _ => panic!("Board failed to continue processing after iteration {iter}"),

--- a/src/gameplay/board.rs
+++ b/src/gameplay/board.rs
@@ -136,6 +136,9 @@ impl Board<ProcessesRows> {
             .grid
             .contains(&Grid::ROWS[self.state.current].clone().into());
 
+        let next_row;
+        let pruned_grid;
+
         // Check next row
         if fully_populated {
             // Move all rows by one and clear the topmost row
@@ -147,26 +150,34 @@ impl Board<ProcessesRows> {
 
             // We have to recheck the current row since the row that used to be
             // above might be fully populated, too.
-            let next_row = self.state.current;
+            next_row = self.state.current;
+            pruned_grid = ExtGrid::from(shifted).union(&ExtGrid::RIM);
+        } else {
+            next_row = self.state.current + 1;
+            pruned_grid = self.grid;
+        }
 
-            Either::Left(Board {
-                state: ProcessesRows::new(next_row),
-                grid: ExtGrid::from(shifted).union(&ExtGrid::RIM),
+        // Guard lookahead, so that we do not check beyond the board's extend
+        if next_row >= BOARD_ROWS {
+            return Either::Right(Board {
+                state: TakesTile {},
+                grid: pruned_grid,
+            });
+        }
+
+        // There are no empty interleaving rows, so once we encounter an empty row, we can skip
+        // ahead
+        let next_row_empty = !pruned_grid.overlaps(&Grid::ROWS[next_row].clone().into());
+        if next_row_empty {
+            Either::Right(Board {
+                state: TakesTile {},
+                grid: pruned_grid,
             })
         } else {
-            let next_row = self.state.current + 1;
-
-            if next_row >= BOARD_ROWS {
-                Either::Right(Board {
-                    state: TakesTile {},
-                    grid: self.grid,
-                })
-            } else {
-                Either::Left(Board {
-                    state: ProcessesRows::new(next_row),
-                    grid: self.grid,
-                })
-            }
+            Either::Left(Board {
+                state: ProcessesRows::new(next_row),
+                grid: pruned_grid,
+            })
         }
     }
 }

--- a/src/gameplay/board.rs
+++ b/src/gameplay/board.rs
@@ -126,9 +126,7 @@ impl Rasterization<Passive> for Board<TakesTile> {
 }
 
 impl Board<ProcessesRows> {
-    /// Note that if there are 5 rows to check (i.e. no row is fully populated),
-    /// only 4 calls to `process_row` are necessary, as `process_row` enumerates
-    /// the transitions between rows to check (as opposed to the rows themselves).
+    /// To leave [`ProcessesRows`] state, call `process_row` once per non-empty row.
     #[must_use]
     pub fn process_row(self) -> Either<Board<ProcessesRows>, Board<TakesTile>> {
         // Note that by design, the bottom row cannot be empty when entering

--- a/tests/games.rs
+++ b/tests/games.rs
@@ -198,7 +198,7 @@ fn game_one() -> Result<()> {
     overshoot_tile_to(&mut game, 0, 1)?;
     let game = push_tile_down(game, 3)?;
     check_snapshots(&game, &active, &passive);
-    let game = process_rows(game, 5)?;
+    let game = process_rows(game, 1)?;
 
     // Tile 2 - Line
     println!("Tile 2 - Line");
@@ -223,7 +223,7 @@ fn game_one() -> Result<()> {
     move_tile_to(&mut game, 4)?;
     let game = push_tile_down(game, 3)?;
     check_snapshots(&game, &active, &passive);
-    let game = process_rows(game, 5)?;
+    let game = process_rows(game, 1)?;
 
     // Tile 3 - Diagonal
     println!("Tile 3 - Diagonal");
@@ -246,7 +246,7 @@ fn game_one() -> Result<()> {
     let game = place_tile_continue(game, tile)?;
     let game = push_tile_down(game, 3)?;
     check_snapshots(&game, &active, &passive);
-    let game = process_rows(game, 6)?;
+    let game = process_rows(game, 2)?;
 
     // Tile 4 - Square
     println!("Tile 4 - Square");
@@ -274,7 +274,7 @@ fn game_one() -> Result<()> {
     overshoot_tile_to(&mut game, 5, 2)?;
     let game = push_tile_down(game, 0)?;
     check_snapshots(&game, &active, &passive);
-    let game = process_rows(game, 5)?;
+    let game = process_rows(game, 1)?;
 
     // Tile 5 - Line
     println!("Tile 5 - Line");
@@ -299,7 +299,7 @@ fn game_one() -> Result<()> {
     overshoot_tile_to(&mut game, 0, 1)?;
     let game = push_tile_down(game, 3)?;
     check_snapshots(&game, &active, &passive);
-    let game = process_rows(game, 5)?;
+    let game = process_rows(game, 1)?;
 
     // Tile 6 - Line
     println!("Tile 6 - Line");
@@ -324,7 +324,7 @@ fn game_one() -> Result<()> {
     overshoot_tile_to(&mut game, 0, 1)?;
     let game = push_tile_down(game, 2)?;
     check_snapshots(&game, &active, &passive);
-    let game = process_rows(game, 5)?;
+    let game = process_rows(game, 2)?;
 
     // Tile 7 - Line
     println!("Tile 7 - Line");
@@ -349,7 +349,7 @@ fn game_one() -> Result<()> {
     move_tile_to(&mut game, 3)?;
     let game = push_tile_down(game, 2)?;
     check_snapshots(&game, &active, &passive);
-    let game = process_rows(game, 5)?;
+    let game = process_rows(game, 2)?;
 
     // Tile 8 - Line
     println!("Tile 8 - Line");
@@ -372,7 +372,7 @@ fn game_one() -> Result<()> {
     let game = place_tile_continue(game, tile)?;
     let game = push_tile_down(game, 1)?;
     check_snapshots(&game, &active, &passive);
-    let game = process_rows(game, 5)?;
+    let game = process_rows(game, 4)?;
 
     // Tile 9 - Square
     println!("Tile 9 - Square");
@@ -398,7 +398,7 @@ fn game_one() -> Result<()> {
     overshoot_tile_to(&mut game, 4, 1)?;
     let game = push_tile_down(game, 1)?;
     check_snapshots(&game, &active, &passive);
-    let game = process_rows(game, 5)?;
+    let game = process_rows(game, 4)?;
 
     // Tile 10 - Square
     println!("Tile 10 - Square");
@@ -422,7 +422,7 @@ fn game_one() -> Result<()> {
     move_tile_to(&mut game, 0)?;
     let game = push_tile_down(game, 2)?;
     check_snapshots(&game, &active, &passive);
-    let game = process_rows(game, 5)?;
+    let game = process_rows(game, 4)?;
 
     // Tile 11 - Square
     println!("Tile 11 - Square");
@@ -446,7 +446,7 @@ fn game_one() -> Result<()> {
     move_tile_to(&mut game, 4)?;
     let game = push_tile_down(game, 4)?;
     check_snapshots(&game, &active, &passive);
-    let game = process_rows(game, 6)?;
+    let game = process_rows(game, 4)?;
 
     // Tile 12 - Diagonal
     println!("Tile 12 - Diagonal");
@@ -471,7 +471,7 @@ fn game_one() -> Result<()> {
     move_tile_to(&mut game, 4)?;
     let game = push_tile_down(game, 3)?;
     check_snapshots(&game, &active, &passive);
-    let game = process_rows(game, 6)?;
+    let game = process_rows(game, 3)?;
 
     // Tile 13 - Line
     println!("Tile 13 - Line");
@@ -498,7 +498,7 @@ fn game_one() -> Result<()> {
     overshoot_tile_to(&mut game, 4, 3)?;
     let game = push_tile_down(game, 2)?;
     check_snapshots(&game, &active, &passive);
-    let game = process_rows(game, 5)?;
+    let game = process_rows(game, 2)?;
 
     // Tile 14 - Square
     println!("Tile 14 - Square");
@@ -523,7 +523,7 @@ fn game_one() -> Result<()> {
     move_tile_to(&mut game, 0)?;
     let game = push_tile_down(game, 2)?;
     check_snapshots(&game, &active, &passive);
-    let game = process_rows(game, 5)?;
+    let game = process_rows(game, 2)?;
 
     // Tile 15 - Diagonal
     println!("Tile 15 - Diagonal");
@@ -548,7 +548,7 @@ fn game_one() -> Result<()> {
     rotate_tile_valid(&mut game)?;
     let game = push_tile_down(game, 2)?;
     check_snapshots(&game, &active, &passive);
-    let game = process_rows(game, 6)?;
+    let game = process_rows(game, 3)?;
 
     // Tile 16 - Line
     println!("Tile 16 - Line");
@@ -576,7 +576,7 @@ fn game_one() -> Result<()> {
     move_tile_to(&mut game, 2)?;
     let game = push_tile_down(game, 2)?;
     check_snapshots(&game, &active, &passive);
-    let game = process_rows(game, 5)?;
+    let game = process_rows(game, 2)?;
 
     // Tile 17 - Square
     println!("Tile 17 - Square");
@@ -600,7 +600,7 @@ fn game_one() -> Result<()> {
     move_tile_to(&mut game, 3)?;
     let game = push_tile_down(game, 3)?;
     check_snapshots(&game, &active, &passive);
-    let game = process_rows(game, 5)?;
+    let game = process_rows(game, 2)?;
 
     // Tile 18 - Line
     println!("Tile 18 - Line");
@@ -628,7 +628,7 @@ fn game_one() -> Result<()> {
     move_tile_to(&mut game, 4)?;
     let game = push_tile_down(game, 3)?;
     check_snapshots(&game, &active, &passive);
-    let game = process_rows(game, 7)?;
+    let game = process_rows(game, 2)?;
 
     // Tile 19 - Line
     println!("Tile 19 - Line");
@@ -651,7 +651,7 @@ fn game_one() -> Result<()> {
     let game = place_tile_continue(game, tile)?;
     let game = push_tile_down(game, 3)?;
     check_snapshots(&game, &active, &passive);
-    let game = process_rows(game, 5)?;
+    let game = process_rows(game, 2)?;
 
     // Tile 20 - Line
     println!("Tile 20 - Line");
@@ -674,7 +674,7 @@ fn game_one() -> Result<()> {
     let game = place_tile_continue(game, tile)?;
     let game = push_tile_down(game, 1)?;
     check_snapshots(&game, &active, &passive);
-    let game = process_rows(game, 5)?;
+    let game = process_rows(game, 4)?;
 
     // Tile 21 - Line
     println!("Tile 21 - Line");


### PR DESCRIPTION
This commit implements an early exit condition to leave `Board<ProcessesRows>`
when encountering the first non-empty row.

Closes #31 